### PR TITLE
Fix segfault

### DIFF
--- a/src/parser/nodes/NodeBinary.cpp
+++ b/src/parser/nodes/NodeBinary.cpp
@@ -342,7 +342,7 @@ RaveValue NodeBinary::generate() {
 
             RaveValue value = currScope->getWithoutLoad(id->name, this->loc);
 
-            if(vSecond.type->toString() == value.type->toString()) vSecond = LLVM::load(vSecond, "NodeBinary_NodeIden_load", loc);
+            if(vSecond.type && vSecond.type->toString() == value.type->toString()) vSecond = LLVM::load(vSecond, "NodeBinary_NodeIden_load", loc);
 
             if(instanceof<NodeNull>(this->second)) {
                 ((NodeNull*)(this->second))->type = value.type->getElType();


### PR DESCRIPTION
Built on openSUSE Tumbleweed with LLVM16

```
Starting program: /home/Michael/bin/rave first.rave

Program received signal SIGSEGV, Segmentation fault.
0x00000000004a134e in NodeBinary::generate (this=0x135c590) at src/parser/nodes/NodeBinary.cpp:347
347                 if(vSecond.type->toString() == value.type->toString()) vSecond = LLVM::load(vSecond, "NodeBinary_NodeIden_load", loc);
(gdb) bt
#0  0x00000000004a134e in NodeBinary::generate (this=0x135c590) at src/parser/nodes/NodeBinary.cpp:347
#1  0x0000000000521007 in NodeVar::generate (this=0x135bab0) at src/parser/nodes/NodeVar.cpp:323
#2  0x00000000004a771b in NodeBlock::generate (this=0x1243390) at src/parser/nodes/NodeBlock.cpp:40
#3  0x00000000004df2b5 in NodeFunc::generate (this=0x11c0af0) at src/parser/nodes/NodeFunc.cpp:364
#4  0x000000000049638f in NodeNamespace::generate (this=0x11bf860) at src/parser/nodes/NodeNamespace.cpp:107
#5  0x0000000000496512 in NodeNamespace::generate (this=0x11bf8b0) at src/parser/nodes/NodeNamespace.cpp:116
#6  0x0000000000417eb6 in Compiler::compile (file="/s/Projects/rave/std/utf8.rave") at src/compiler.cpp:358
#7  0x00000000004194ea in Compiler::compileAll () at src/compiler.cpp:478
#8  0x0000000000475616 in main (argc=2, argv=0x7fffffffd378) at src/main.cpp:134
```