### PR TITLE
Support more LLVM variants on windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,13 @@
 BIN = rave
 
-LLVM_VERSION =
-
-LLVM_FLAGS =
-
-LLVM_CONFIG =
-
 FLAGS ?= -O3
-
-LLVM_STATIC ?= 0
 
 COMPILER ?= $(CXX)
 
-LLVM_WIN_LIB ?= ./LLVM/lib/LLVM-C.lib
+LLVM_VERSION =
+LLVM_FLAGS =
+LLVM_CONFIG = llvm-config
+LLVM_STATIC ?= 0
 
 WINBUILD = 0
 ifdef OS
@@ -22,12 +17,34 @@ ifdef OS
 endif
 
 ifeq ($(WINBUILD),1)
-	temp_llvmver = $(shell llvm-config --version)
-	LLVM_VERSION = $(firstword $(subst ., ,$(temp_llvmver)))
 	BIN = rave.exe
+	ifeq (, $(shell command -v $(LLVM_CONFIG)))
+		LLVM_CONFIG = ./LLVM/bin/llvm-config.exe
+	endif
+	LLVM_FULL_VERSION = $(shell $(LLVM_CONFIG) --version)
+	LLVM_VERSION = $(firstword $(subst ., ,$(LLVM_FULL_VERSION)))
+	# We assume that if this config query outputs 'shared' then LLVM can be linked in both ways
+	# Otherwise static only
+	ifneq (shared, $(shell $(LLVM_CONFIG) --shared-mode))
+		LLVM_STATIC = 1
+		LLVM_NO_SHARED = 1
+	endif
+	# the following branch is thoughtful, as LLVM_STATIC has priority over llvm's default mode
+	LLVM_STATIC_FLAG1 =
+	LLVM_STATIC_FLAG2 =
+	ifeq ($(LLVM_STATIC), 1)
+		LLVM_STATIC_FLAG1 = --link-static
+		LLVM_STATIC_FLAG2 = --system-libs
+	endif
+	LLVM_LINK_FLAGS = `$(LLVM_CONFIG) $(LLVM_STATIC_FLAG1) $(LLVM_STATIC_FLAG2) --libs`
+	LLVM_LIBDIR = $(shell $(LLVM_CONFIG) $(LLVM_STATIC_FLAG1) --libdir)
+	ifeq ($(LLVM_NO_SHARED), 1)
+		# I've tried many LLVMs for Windows and concluded that
+		# if it supports only static linkage, it won't include this library into `llvm-config --libs`
+		LLVM_LINK_FLAGS = "$(LLVM_LIBDIR)/LLVM-C.lib"
+	endif
 	SRC = $(patsubst ".\\%",$ .\src\\%, $(shell ./getFiles.sh))
-	LLVM_COMPILE_FLAGS = `llvm-config --cflags`
-	LLVM_LINK_FLAGS = `llvm-config --libs`
+	LLVM_COMPILE_FLAGS = `$(LLVM_CONFIG) --cflags`
 else
 	ifneq (, $(shell command -v llvm-config-16))
  		LLVM_VERSION = 16
@@ -38,14 +55,14 @@ else
 		LLVM_CONFIG = llvm-config-15
 	else
 	ifneq (, $(shell command -v llvm-config))
-		temp_llvmver = $(shell llvm-config --version)
-		LLVM_VERSION = $(firstword $(subst ., ,$(temp_llvmver)))
+		LLVM_FULL_VERSION = $(shell llvm-config --version)
+		LLVM_VERSION = $(firstword $(subst ., ,$(LLVM_FULL_VERSION)))
 		LLVM_CONFIG = llvm-config
 	endif
 	endif
 	endif
 	ifeq ($(LLVM_STATIC), 1)
-		LLVM_FLAGS = `$(LLVM_CONFIG) --ldflags --link-static --libs --system-libs --cxxflags --link-static`
+		LLVM_FLAGS = `$(LLVM_CONFIG) --ldflags --link-static --libs --system-libs --cxxflags`
 	else
 		LLVM_FLAGS = `$(LLVM_CONFIG) --libs --cxxflags`
 	endif
@@ -68,7 +85,7 @@ obj/linux/%.o: %.cpp
 	$(COMPILER) -c $< -o $@ -DLLVM_VERSION=$(LLVM_VERSION) -std=c++17 -Wno-deprecated $(FLAGS) $(LLVM_FLAGS) -fexceptions
 else
 $(BIN): $(OBJ)
-	$(COMPILER) $(OBJ) -o $@ $(LLVM_WIN_LIB) $(LLVM_LINK_FLAGS) -DLLVM_VERSION=$(LLVM_VERSION) -lstdc++
+	$(COMPILER) $(OBJ) -o $@ $(LLVM_LINK_FLAGS) -DLLVM_VERSION=$(LLVM_VERSION) -lstdc++
 obj/win/%.o: %.cpp
 	$(shell mkdir -p obj/win/src/parser/nodes obj/win/src/lexer)
 	$(COMPILER) -c $< -o $@ -DLLVM_VERSION=$(LLVM_VERSION) -std=c++17 -Wno-deprecated $(FLAGS) $(LLVM_COMPILE_FLAGS) -fexceptions

--- a/src/include/parser/ast.hpp
+++ b/src/include/parser/ast.hpp
@@ -10,6 +10,10 @@ with this file, You can obtain one at http://mozilla.org/MPL/2.0/.
 #include <map>
 #include <llvm-c/Core.h>
 
+#ifndef LLVM_VERSION
+#error LLVM_VERSION is required
+#endif
+
 #if LLVM_VERSION < 17
 #include <llvm-c/Initialization.h>
 #endif


### PR DESCRIPTION
Tried variants:
terralang/llvm-build (static link), building with mstorsjo/llvm-mingw
c3lang/win-llvm (static link), building with mstorsjo/llvm-mingw
LLVM from MSYS2 (dynamic & static), the same is used for build